### PR TITLE
Fixed the condition that assign the value to the parameter 'Integrated Security' in the Runner.

### DIFF
--- a/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
@@ -34,7 +34,7 @@ internal static class ReportUtils
             {
                 new NameValuePair2("Data Source", report.Connection.Server),
                 new NameValuePair2("Initial Catalog", report.Connection.Database),
-                new NameValuePair2("Integrated Security", report.Connection.UseIntegratedSecurity.ToString()),
+                new NameValuePair2("Integrated Security", report.Connection.UseIntegratedSecurity ? "True" : "False"),
             };
             if (report.Connection.LogonProperties is not null)
             {

--- a/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
@@ -34,7 +34,7 @@ internal static class ReportUtils
             {
                 new NameValuePair2("Data Source", report.Connection.Server),
                 new NameValuePair2("Initial Catalog", report.Connection.Database),
-                new NameValuePair2("Integrated Security", report.Connection.UseIntegratedSecurity ? "False" : "True"),
+                new NameValuePair2("Integrated Security", report.Connection.UseIntegratedSecurity.ToString()),
             };
             if (report.Connection.LogonProperties is not null)
             {


### PR DESCRIPTION
Fixed the condition that assign the value to the parameter 'Integrated Security', before UseIntegratedSecurity = false set the parameter 'Integrated Security' to 'True' and vice versa, now value true sets parameter to 'True' and false to 'False'.

This was causing the error 'Could  not connect to Database'.