### PR TITLE
Set current values directly on parameter

### DIFF
--- a/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportUtils.cs
@@ -104,7 +104,8 @@ internal static class ReportUtils
             if (report.Parameters.TryGetValue(parameter.ParameterFieldName, out var value))
             {
                 Logger.Trace($"LijsDev::CrystalReportsRunner::ReportUtils::CreateReportDocument::SetParameter={parameter.ParameterFieldName} | Value={value}");
-                document.SetParameterValue(parameter.ParameterFieldName, value);
+                parameter.CurrentValues.Clear();
+                parameter.CurrentValues.Add(value);
             }
         }
 


### PR DESCRIPTION
Fix for #9 

The problem is in the applying values for parameter. In case of multiple subreports with the exact same parameter name, SetParameterValue applies value to the first found parameter, instead of all of them. So we need to apply this value to currently iterated parameter.