### PR TITLE
ShowDialog can now be displayed in landscape orientation

### DIFF
--- a/src/LijsDev.CrystalReportsRunner/shared/ReportViewer.cs
+++ b/src/LijsDev.CrystalReportsRunner/shared/ReportViewer.cs
@@ -21,10 +21,10 @@ internal class ReportViewer : IReportViewer
 
         // Print options
         document.PrintOptions.PaperOrientation = (PaperOrientation)report.PaperOrientation;
-
-        // NB: We need to set this in the report options or programatically for Landscape to display correctly.
-        // Leave it as it is but can be enabled for testing purposes.
-        //document.PrintOptions.DissociatePageSizeAndPrinterPaperSize = false;
+        if (report.PaperOrientation == PaperOrientations.Landscape)
+        {
+            document.PrintOptions.DissociatePageSizeAndPrinterPaperSize = false;
+        }
 
         return new ViewerForm(document, viewerSettings)
         {

--- a/tests/shared/CrystalReportsRunnerTests.cs
+++ b/tests/shared/CrystalReportsRunnerTests.cs
@@ -120,6 +120,41 @@ public class CrystalReportsTests
         form.ShowDialog();
     }
 
+    /// <summary>
+    /// Test a simple sample landscape report without database connection, sending the DataSet with int/string/byte[] fields.
+    /// </summary>
+    [TestMethod]
+    public void SampleReportDataset_ShowDialog_WithLandscape_ShouldWork()
+    {
+        var report = new Report("SampleReportDataset.rpt", "Sample Report Dataset");
+        report.Parameters.Add("ReportFrom", new DateTime(2022, 01, 01));
+        report.Parameters.Add("UserName", "Gerardo");
+        // Set landcape orientation
+        report.PaperOrientation = PaperOrientations.Landscape;
+
+        // Create dataset
+        var sampleReportDataset = new System.Data.DataSet();
+
+        // Create table
+        var personsTable = new System.Data.DataTable("Persons");
+        sampleReportDataset.Tables.Add(personsTable);
+        personsTable.Columns.Add("Id", typeof(int));
+        personsTable.Columns.Add("Name", typeof(string));
+        personsTable.Columns.Add("Age", typeof(int));
+        personsTable.Columns.Add("PersonImage", typeof(byte[]));
+
+        // Add rows
+        personsTable.Rows.Add(1, "Gerardo", "42", File.ReadAllBytes("sampleImage1.jpg"));
+        personsTable.Rows.Add(2, "Khalifa", "24", File.ReadAllBytes("sampleImage2.jpg"));
+
+        report.DataSets.Add(sampleReportDataset);
+
+        var reportViewer = new LijsDev.CrystalReportsRunner.ReportViewer();
+        var form = reportViewer.GetViewerForm(report, new ReportViewerSettings());
+        form.ShowDialog();
+    }
+
+
     [TestMethod]
     public void SampleReport_CreateReportDocument_ShouldWork()
     {


### PR DESCRIPTION
The following property needs to be set to false to display in landscape mode, so this has been fixed.

> document.PrintOptions.DissociatePageSizeAndPrinterPaperSize = false;

Also added a test for landscape display.